### PR TITLE
Add ability to parse system time

### DIFF
--- a/bin/metrics-chrony.rb
+++ b/bin/metrics-chrony.rb
@@ -34,7 +34,7 @@ class ChronyMetrics < Sensu::Plugin::Metric::CLI::Graphite
          description: 'Metric naming scheme, text to prepend to metric',
          short: '-s SCHEME',
          long: '--scheme SCHEME',
-         default: Socket.gethostname
+         default: "#{Socket.gethostname}.chronystats"
 
   def run
     # #YELLOW
@@ -45,11 +45,11 @@ class ChronyMetrics < Sensu::Plugin::Metric::CLI::Graphite
     chronystats = get_chronystats(config[:host])
     critical "Failed to get chronycstats from #{config[:host]}" if chronystats.empty?
     metrics = {
-      chronystats: chronystats
+      config[:scheme] => chronystats
     }
     metrics.each do |name, stats|
       stats.each do |key, value|
-        output([config[:scheme], name, key].join('.'), value)
+        output([name, key].join('.'), value)
       end
     end
     ok


### PR DESCRIPTION
TL;DR This PR adds ability to parse the System time in `chronyc tracking`. Also it changes `--scheme` option to follow the commonly used practice, that is `--schema` option replaces `$HOSTNAME.chronystats` rather than just the `$HOSTNAME`.

There was my [PR](https://github.com/sensu/sensu-community-plugins/pull/1194) to add `metrics-chrony.rb` in the community plugins in 2015, which wasn't merged or integrated to the new plugins collection in the end.

The only big difference with this plugin is mine could parse the system time. This PR adds the system time by filtering out uninteresting metrics rather than including it explicitly. This way the plugin is likely to be able to support any future metrics without updating the list.

Output should be the same besides `system_time` as long as `--scheme` isn't specified. If `--schema` is given, there should be a difference:

before:

```
% metrics-chrony.rb -s foo
foo.chronystats.stratum 5 1465973997
foo.chronystats.system_time 1.4721e-05 1465973997
foo.chronystats.last_offset 1.9449e-05 1465973997
foo.chronystats.rms_offset 7.3826e-05 1465973997
foo.chronystats.frequency 27.444 1465973997
foo.chronystats.residual_freq 0.003 1465973997
foo.chronystats.skew 0.038 1465973997
foo.chronystats.root_delay 0.009738 1465973997
foo.chronystats.root_dispersion 0.025288 1465973997
foo.chronystats.update_interval 256.7 1465973997
```

after:

```
% metrics-chrony.rb -s foo
foo.stratum 5 1465973997
foo.system_time 1.4721e-05 1465973997
foo.last_offset 1.9449e-05 1465973997
foo.rms_offset 7.3826e-05 1465973997
foo.frequency 27.444 1465973997
foo.residual_freq 0.003 1465973997
foo.skew 0.038 1465973997
foo.root_delay 0.009738 1465973997
foo.root_dispersion 0.025288 1465973997
foo.update_interval 256.7 1465973997
```

This behavior seems common in the official plugins. See [metrics-cpu.rb](https://github.com/sensu-plugins/sensu-plugins-cpu-checks/blob/master/bin/metrics-cpu.rb#L37) for example.
