### PR TITLE
fix offset and stratum checks to be able to send warn

### DIFF
--- a/bin/check-chrony.rb
+++ b/bin/check-chrony.rb
@@ -131,7 +131,7 @@ class CheckChrony < Sensu::Plugin::Check::CLI
         send_critical(check_name, msg)
       elsif stratum >= config[:warn_stratum]
         msg += ", expected < #{config[:warn_stratum]}"
-        send_critical(check_name, msg)
+        send_warning(check_name, msg)
       else
         send_ok(check_name, msg)
       end
@@ -147,8 +147,8 @@ class CheckChrony < Sensu::Plugin::Check::CLI
         msg += ", expected > -#{config[:crit_offset]} and < #{config[:crit_offset]}"
         send_critical(check_name, msg)
       elsif offset >= config[:warn_offset] || offset < -config[:warn_offset]
-        msg += ", expected > -#{config[:crit_offset]} and < #{config[:warn_offset]}"
-        send_critical(check_name, msg)
+        msg += ", expected > -#{config[:warn_offset]} and < #{config[:warn_offset]}"
+        send_warning(check_name, msg)
       else
         send_ok(check_name, msg)
       end


### PR DESCRIPTION
Offset and stratum were sending critical messages  even when only warning
thresholds were crossed.

Also fix offset warn msg to use lower warn threshold instead of
lower critical threshold.

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
