### PR TITLE
Update plugin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 
 [![Build Status](https://travis-ci.org/sensu-plugins/sensu-plugins-chrony.svg?branch=master)](https://travis-ci.org/sensu-plugins/sensu-plugins-chrony)
 [![Gem Version](https://badge.fury.io/rb/sensu-plugins-chrony.svg)](https://badge.fury.io/rb/sensu-plugins-chrony)
-[![Code Climate](https://codeclimate.com/github/sensu-plugins/sensu-plugins-chrony/badges/gpa.svg)](https://codeclimate.com/github/sensu-plugins/sensu-plugins-chrony)
-[![Test Coverage](https://codeclimate.com/github/sensu-plugins/sensu-plugins-chrony/badges/coverage.svg)](https://codeclimate.com/github/sensu-plugins/sensu-plugins-chrony)
-[![Dependency Status](https://gemnasium.com/sensu-plugins/sensu-plugins-chrony.svg)](https://gemnasium.com/sensu-plugins/sensu-plugins-chrony)
 [![Community Slack](https://slack.sensu.io/badge.svg)](https://slack.sensu.io/badge)
 
 A sensu plugin to monitor Chrony NTP. There is also a metrics plugin for collecting things like offset, delay etc.
@@ -33,12 +30,12 @@ The plugin accepts the following command line options:
 
 ```
 Usage: check-chrony.rb (options)
-    -c, --chronyc-cmd <PATH>         Path to chronyc executable (default: /usr/bin/chronyc)
-        --crit-offset <OFFSET>       Critical if OFFSET exceeds current offset (ms)
+    -C, --chronyc-cmd <PATH>         Path to chronyc executable (default: /usr/bin/chronyc)
+    -c, --crit-offset <OFFSET>       Critical if OFFSET exceeds current offset (ms)
         --crit-stratum <STRATUM>     Critical if STRATUM exceeds current stratum
         --dryrun                     Do not send events to sensu client socket
-        --handlers <HANDLERS>        Comma separated list of handlers
-        --warn-offset <OFFSET>       Warn if OFFSET exceeds current offset (ms)
+        --handlers <HANDLER>         Comma separated list of handlers
+    -w, --warn-offset <OFFSET>       Warn if OFFSET exceeds current offset (ms)
         --warn-stratum <STRATUM>     Warn if STRATUM exceeds current stratum
 ```
 

--- a/bin/check-chrony.rb
+++ b/bin/check-chrony.rb
@@ -14,18 +14,20 @@ require 'json'
 class CheckChrony < Sensu::Plugin::Check::CLI
   option :chronyc_cmd,
          description: 'Path to chronyc executable (default: /usr/bin/chronyc)',
-         short: '-c <PATH>',
+         short: '-C <PATH>',
          long: '--chronyc-cmd <PATH>',
          default: '/usr/bin/chronyc'
 
   option :warn_offset,
          description: 'Warn if OFFSET exceeds current offset (ms)',
+         short: '-w <OFFSET>',
          long: '--warn-offset <OFFSET>',
          proc: proc(&:to_f),
          default: 50
 
   option :crit_offset,
          description: 'Critical if OFFSET exceeds current offset (ms)',
+         short: '-c <OFFSET>',
          long: '--crit-offset <OFFSET>',
          proc: proc(&:to_f),
          default: 100


### PR DESCRIPTION
Update short option for `chrony_cmd` and add a new short option for `warn_offset` and `crit_offset` symbols.

## Pull Request Checklist

**Is this in reference to an existing issue?**
No

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
